### PR TITLE
Fix tyop on landing page

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -1,11 +1,11 @@
 ---
 date: 2023-03-21T7:00:00Z
 title: PKI Maturity Model (PKIMM)
-summary: The PKI Maturity Model draws inspiration from the renowned Capability Maturity Model Integration (CMMI) developed by Carnegie Mellon University. It provides organizations with the tools to gGain swift insight into the current capabilities and performance of their PKI, facilitate confidential benchmarking against similar entities based on size or industry, receive actionable guidance to enhance PKI capabilities, and elevate overall PKI performance.
+summary: The PKI Maturity Model draws inspiration from the renowned Capability Maturity Model Integration (CMMI) developed by Carnegie Mellon University. It provides organizations with the tools to gain swift insight into the current capabilities and performance of their PKI, facilitate confidential benchmarking against similar entities based on size or industry, receive actionable guidance to enhance PKI capabilities, and elevate overall PKI performance.
 sideMenu: true
 
 heroTitle: PKI Maturity Model (PKIMM)
-heroDescription: The PKI Maturity Model draws inspiration from the renowned Capability Maturity Model Integration (CMMI) developed by Carnegie Mellon University. It provides organizations with the tools to gGain swift insight into the current capabilities and performance of their PKI, facilitate confidential benchmarking against similar entities based on size or industry, receive actionable guidance to enhance PKI capabilities, and elevate overall PKI performance.
+heroDescription: The PKI Maturity Model draws inspiration from the renowned Capability Maturity Model Integration (CMMI) developed by Carnegie Mellon University. It provides organizations with the tools to gain swift insight into the current capabilities and performance of their PKI, facilitate confidential benchmarking against similar entities based on size or industry, receive actionable guidance to enhance PKI capabilities, and elevate overall PKI performance.
 
 tags:
   - resource


### PR DESCRIPTION
Typo on the landing page:

> It provides organizations with the tools to **gGain** swift insight into the current capabilities and performance of their PKI

This fixes that.