### PR TITLE
Rename _build front matter to build

### DIFF
--- a/categories/templates/_index.md
+++ b/categories/templates/_index.md
@@ -1,7 +1,7 @@
 ---
 date: 2023-03-21T7:00:00Z
 title: Template
-_build:
+build:
   render: never
   list: never
 

--- a/extensions/catalog/templates/_index.md
+++ b/extensions/catalog/templates/_index.md
@@ -1,7 +1,7 @@
 ---
 date: "2026-05-13T7:00:00Z"
 title: Extension documentation template
-_build:
+build:
   render: never
   list: never
 

--- a/release-notes/templates/_index.md
+++ b/release-notes/templates/_index.md
@@ -1,7 +1,7 @@
 ---
 date: 1970-01-01T00:00:00Z
 title: Template
-_build:
+build:
   render: never
   list: never
 ---

--- a/tools/self-assessment/_index.md
+++ b/tools/self-assessment/_index.md
@@ -3,7 +3,7 @@ title: PKI Maturity Model Self Assessment Tool
 summary: Self Assessment Tool for the PKI Maturity Model of the PKI Consortium
 date: 2024-09-14T20:00:00+00:00
 fullwidth: true
-_build:
+build:
   render: never
   list: never
 


### PR DESCRIPTION
Hugo 0.145.0 deprecated the `_build` front-matter key in favor of `build`. Updates the four pages that use it.

## Changes

- `categories/templates/_index.md` (also fixes a YAML typo `Hugo _build:` → `build:`)
- `extensions/catalog/templates/_index.md`
- `release-notes/templates/_index.md`
- `tools/self-assessment/_index.md`

Same `render: never` / `list: never` semantics — just the key name change.
