### PR TITLE
Fix typo in policy-scope requirement description

### DIFF
--- a/categories/policies-and-documentation/_index.md
+++ b/categories/policies-and-documentation/_index.md
@@ -35,7 +35,7 @@ The Certificate Policy (CP) defines the overall policies and requirements of a P
 
 | ID | Requirement | Weight |
 |----|-------------|-------:|
-| [`policy-scope`](#policy-scope) | he scope of policies is defined and documented | 2 |
+| [`policy-scope`](#policy-scope) | The scope of policies is defined and documented | 2 |
 | [`certificate-policy`](#certificate-policy) | Certificate policy is documented and published | 5 |
 | [`practice-statement`](#practice-statement) | Certification practice statement is documented and published | 5 |
 | [`disclosure-statement`](#disclosure-statement) | Disclosure statement is documented and published | 4 |
@@ -44,7 +44,7 @@ The Certificate Policy (CP) defines the overall policies and requirements of a P
 ## Details
 
 <a id="policy-scope"></a>
-### he scope of policies is defined and documented
+### The scope of policies is defined and documented
 
 #### Guidance
 

--- a/data/pkimm-model-1.0.0.yaml
+++ b/data/pkimm-model-1.0.0.yaml
@@ -150,7 +150,7 @@ modules:
         requirements:
           - id: "1"
             weight: 2
-            description: "he scope of policies is defined and documented"
+            description: "The scope of policies is defined and documented"
             guidance: |
               Each PKI implementation and use case is different, therefore it requires different care. The scope of policies that are applicable for the implementation should be defined and documented. When the proper description of the policies scope is provided, it helps all parties involved to understand the purpose of the policies and their applicability.
 

--- a/data/pkimm-model-2.0.0.yaml
+++ b/data/pkimm-model-2.0.0.yaml
@@ -150,7 +150,7 @@ modules:
     requirements:
     - id: policy-scope
       weight: 2
-      description: he scope of policies is defined and documented
+      description: The scope of policies is defined and documented
       guidance: |
         Each PKI implementation and use case is different, therefore it requires different care. The scope of policies that are applicable for the implementation should be defined and documented. When the proper description of the policies scope is provided, it helps all parties involved to understand the purpose of the policies and their applicability.
 

--- a/integrations/eramba/pkimm-1.0.0.csv
+++ b/integrations/eramba/pkimm-1.0.0.csv
@@ -95,7 +95,7 @@ It consists of:
 Properly documented policies keeps the PKI assets trusted over the time and serves as a basis for integrated processes and procedures. It is a living management system that is continuously updated and changed as technologies, security, and compliance requirements change.
 
 The Certificate Policy (CP) defines the overall policies and requirements of a PKI, the Certification Practice Statement (CPS) provides detailed operational procedures followed by the Certification Authority (CA), and the disclosure statement offers transparency about the CA's identity and services to relying parties.
-",G.2.1,he scope of policies is defined and documented,"Each PKI implementation and use case is different, therefore it requires different care. The scope of policies that are applicable for the implementation should be defined and documented. When the proper description of the policies scope is provided, it helps all parties involved to understand the purpose of the policies and their applicability.
+",G.2.1,The scope of policies is defined and documented,"Each PKI implementation and use case is different, therefore it requires different care. The scope of policies that are applicable for the implementation should be defined and documented. When the proper description of the policies scope is provided, it helps all parties involved to understand the purpose of the policies and their applicability.
 
 The scope can include the following:
 - Identification of the policies required for the implementation

--- a/integrations/eramba/pkimm-2.0.0.csv
+++ b/integrations/eramba/pkimm-2.0.0.csv
@@ -91,7 +91,7 @@ It consists of:
 Properly documented policies keeps the PKI assets trusted over the time and serves as a basis for integrated processes and procedures. It is a living management system that is continuously updated and changed as technologies, security, and compliance requirements change.
 
 The Certificate Policy (CP) defines the overall policies and requirements of a PKI, the Certification Practice Statement (CPS) provides detailed operational procedures followed by the Certification Authority (CA), and the disclosure statement offers transparency about the CA's identity and services to relying parties.
-",G.policies-and-documentation.policy-scope,he scope of policies is defined and documented,"Each PKI implementation and use case is different, therefore it requires different care. The scope of policies that are applicable for the implementation should be defined and documented. When the proper description of the policies scope is provided, it helps all parties involved to understand the purpose of the policies and their applicability.
+",G.policies-and-documentation.policy-scope,The scope of policies is defined and documented,"Each PKI implementation and use case is different, therefore it requires different care. The scope of policies that are applicable for the implementation should be defined and documented. When the proper description of the policies scope is provided, it helps all parties involved to understand the purpose of the policies and their applicability.
 
 The scope can include the following:
 - Identification of the policies required for the implementation
@@ -1864,8 +1864,7 @@ Different methods can be applied to provide security awareness, for example:
 
 References
 - NIST SP 800-50 Building an Information Technology Security Awareness and Training Program
-- PCI SSC - Best Practices for Implementing a
-  Security Awareness Program
+- PCI SSC - Best Practices for Implementing a Security Awareness Program
 - Raising Awareness of Cybersecurity"
 R.knowledge-and-training,Knowledge and training,"The purpose of this category is to ensure that the PKI personnel have the required knowledge and skills to perform their duties and responsibilities.
 Education and continuous gathering of required knowledge and skills to manage the PKI is important to be aware and properly react to current trends and threats that may impact the PKI.

--- a/model/references/_index.md
+++ b/model/references/_index.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20T00:00:00Z
+date: 2026-05-21T00:00:00Z
 title: References
 weight: 4
 ---


### PR DESCRIPTION
Fixes the `policy-scope` requirement description in both model versions: `he scope of policies is defined and documented` → `The scope of policies is defined and documented`.

Generated artifacts regenerated to match: `categories/policies-and-documentation/_index.md`, `integrations/eramba/pkimm-1.0.0.csv`, `integrations/eramba/pkimm-2.0.0.csv`.
